### PR TITLE
rerank: add new param to endpoint

### DIFF
--- a/cohere_sagemaker/client.py
+++ b/cohere_sagemaker/client.py
@@ -275,12 +275,14 @@ class Client:
                query: str,
                documents: Union[List[str], List[Dict[str, Any]]],
                top_n: Optional[int] = None,
-               variant: Optional[str] = None) -> Reranking:
+               variant: Optional[str] = None,
+               max_chunks_per_doc: Optional[int] = None) -> Reranking:
         """Returns an ordered list of documents oridered by their relevance to the provided query
         Args:
             query (str): The search query
             documents (list[str], list[dict]): The documents to rerank
             top_n (int): (optional) The number of results to return, defaults to return all results
+            max_chunks_per_doc (int): (optional) The maximum number of chunks derived from a document
         """
 
         if self._endpoint_name is None:
@@ -300,7 +302,8 @@ class Client:
             "query": query,
             "documents": parsed_docs,
             "top_n": top_n,
-            "return_documents": False
+            "return_documents": False,
+            "max_chunks_per_doc" : max_chunks_per_doc
         }
         json_body = json.dumps(json_params)
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere-sagemaker',
-                 version='0.5.0',
+                 version='0.5.1',
                  author='Cohere',
                  author_email='support@cohere.ai',
                  description='A Python library for the Cohere endpoints in AWS Sagemaker',


### PR DESCRIPTION
Rerank v2.0 adds a new parameter `max_chunks_per_doc` which is an optional int.
Bumps sdk version to 0.5.1.