### PR TITLE
Fix incompatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cohere Python SDK (AWS SageMaker)
 
-This package provides functionality developed to simplify interfacing with the [Cohere models via AWS SageMaker Marketplace](https://aws.amazon.com/marketplace/pp/prodview-6dmzzso5vu5my) in Python 3.
+This package provides functionality developed to simplify interfacing with the [Cohere models via AWS SageMaker Marketplace](https://aws.amazon.com/marketplace/pp/prodview-6dmzzso5vu5my) in Python >=3.6
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere-sagemaker',
-                 version='0.6.0',
+                 version='0.6.1',
                  author='Cohere',
                  author_email='support@cohere.ai',
                  description='A Python library for the Cohere endpoints in AWS Sagemaker',
@@ -32,7 +32,7 @@ setuptools.setup(name='cohere-sagemaker',
                  long_description_content_type='text/markdown',
                  url='https://github.com/cohere-ai/cohere-sagemaker',
                  packages=setuptools.find_packages(),
-                 install_requires=['boto3'],
+                 install_requires=['boto3', 'sagemaker'],
                  include_package_data=True,
                  classifiers=[
                      'Programming Language :: Python :: 3',


### PR DESCRIPTION
- Fix an f-string formatting which only works with python 3.8+.
- Add `try-except` around `model.deploy()` as some validation params do not work with some sagemaker versions which come with python3.6 
- add `sagemaker` as required dependency
- bump version to `0.6.1`