### PR TITLE
Add SDK support for num_generations

### DIFF
--- a/cohere_sagemaker/client.py
+++ b/cohere_sagemaker/client.py
@@ -196,8 +196,7 @@ class Client:
         model: Optional[str] = None,
         # requires DB with presets
         # preset: str = None,
-        # not implemented in API
-        # num_generations: int = 1,
+        num_generations: int = 1,
         max_tokens: int = 20,
         temperature: float = 1.0,
         k: int = 0,
@@ -221,7 +220,8 @@ class Client:
             'p': p,
             'stop_sequences': stop_sequences,
             'return_likelihoods': return_likelihoods,
-            'truncate': truncate
+            'truncate': truncate,
+            'num_generations': num_generations,
         }
         for key, value in list(json_params.items()):
             if value is None:


### PR DESCRIPTION
It's supported both on platform and in Sagemaker

Tested:
```
>>> co.generate(prompt="tell me a story", num_generations=2)
cohere.Generations {
     generations: [cohere.Generation {
     Once upon a time, in a village nestled deep in the forest, there lived a group of creatures
     token_likelihoods: None
}, cohere.Generation {
     text:  Once upon a time, there was a little girl named Emily. Emily had a best friend named Michael
     token_likelihoods: None
}]
}
```