### PR TITLE
Support streaming

### DIFF
--- a/cohere_sagemaker/client.py
+++ b/cohere_sagemaker/client.py
@@ -245,7 +245,7 @@ class Client:
                 return StreamingGenerations(result['Body'])
             else:
                 result = self._client.invoke_endpoint(**params)
-                return Generations.from_dict(json.loads(result['Body'].read().decode()))
+                return Generations(json.loads(result['Body'].read().decode())['generations'])
         except EndpointConnectionError as e:
             raise CohereError(str(e))
         except Exception as e:

--- a/cohere_sagemaker/client.py
+++ b/cohere_sagemaker/client.py
@@ -241,18 +241,19 @@ class Client:
 
         try:
             if stream:
-                result = self._client.invoke_endpoint_with_response_stream(**params)
+                result = self._client.invoke_endpoint_with_response_stream(
+                    **params)
                 return StreamingGenerations(result['Body'])
             else:
                 result = self._client.invoke_endpoint(**params)
-                return Generations(json.loads(result['Body'].read().decode())['generations'])
+                return Generations(
+                    json.loads(result['Body'].read().decode())['generations'])
         except EndpointConnectionError as e:
             raise CohereError(str(e))
         except Exception as e:
             # TODO should be client error - distinct type from CohereError?
             # ValidationError, e.g. when variant is bad
             raise CohereError(str(e))
-
 
     def embed(
         self,

--- a/cohere_sagemaker/generation.py
+++ b/cohere_sagemaker/generation.py
@@ -1,5 +1,6 @@
 from cohere_sagemaker.response import CohereObject
-from typing import List
+from typing import List, Optional, NamedTuple, Generator, Dict, Any
+import json
 
 
 class TokenLikelihood(CohereObject):
@@ -22,8 +23,75 @@ class Generations(CohereObject):
         self.generations = generations
         self.iterator = iter(generations)
 
+    @classmethod
+    def from_dict(cls, response: Dict[str, Any]) -> List[Generation]:
+        generations: List[Generation] = []
+        for gen in response['generations']:
+            token_likelihoods = None
+
+            if 'token_likelihoods' in gen:
+                token_likelihoods = []
+                for likelihoods in gen['token_likelihoods']:
+                    token_likelihood = likelihoods['likelihood'] if 'likelihood' in likelihoods else None
+                    token_likelihoods.append(TokenLikelihood(likelihoods['token'], token_likelihood))
+            generations.append(Generation(gen['text'], token_likelihoods))
+        return cls(generations)
+
     def __iter__(self) -> iter:
         return self.iterator
 
     def __next__(self) -> next:
         return next(self.iterator)
+
+
+StreamingText = NamedTuple("StreamingText", [("index", Optional[int]), ("text", str), ("is_finished", bool)])
+
+class StreamingGenerations(CohereObject):
+    def __init__(self, stream):
+        self.stream = stream
+        self.id = None
+        self.generations = None
+        self.finish_reason = None
+        self.texts = []
+        self.bytes = bytearray()
+
+    def _make_response_item(self, streaming_item) -> Optional[StreamingText]:
+        is_finished = streaming_item.get("is_finished")
+
+        if not is_finished:
+            index = streaming_item.get("index", 0)
+            text = streaming_item.get("text")
+            while len(self.texts) <= index:
+                self.texts.append("")
+            if text is None:
+                return None
+            self.texts[index] += text
+            return StreamingText(text=text, is_finished=is_finished, index=index)
+
+        self.finish_reason = streaming_item.get("finish_reason")
+        generation_response = streaming_item.get("response")
+
+        if generation_response is None:
+            return None
+
+        self.id = generation_response.get("id")
+        self.generations = Generations.from_dict(generation_response)
+        return None
+
+    def __iter__(self) -> Generator[StreamingText, None, None]:
+        for payload in self.stream:
+            self.bytes.extend(payload['PayloadPart']['Bytes'])
+            try:
+                item = self._make_response_item(json.loads(self.bytes))
+            except json.decoder.JSONDecodeError:
+                # payload contained only a partion JSON object
+                continue
+
+            self.bytes = bytearray()
+            if item is not None:
+                yield item
+
+    def __repr__(self) -> str:
+        for x in self:
+            continue
+        return str(self.generations)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -6,7 +6,6 @@ from botocore.stub import Stubber
 from botocore.response import StreamingBody
 from io import BytesIO
 from typing import Dict, Optional, Any
-from unittest.mock import Mock
 
 
 class TestClient(unittest.TestCase):


### PR DESCRIPTION
Tried to stay as close as possible to streaming behaviour/implementation in [cohere-python](https://github.com/cohere-ai/cohere-python/blob/6ed277ae8062a8a7a18783feca1691512047c29b/cohere/responses/generation.py)

The botocore stubber is broken for the streaming endpoint so I used actual api calls in the test for now.
Code snippet for calling the streaming endpoint:

```
import cohere_sagemaker

co = cohere_sagemaker.Client(region_name="us-west-2")
co.connect_to_endpoint("cohere-gpt-medium")
stream = co.generate(prompt="tell me a story",max_tokens=50,variant="p4d",num_generations=2)
for s in stream:
    print(s)
```

Note that the Bedrock launch is Thurs, so please review with that in mind - happy to add TODOs but please prioritize helping me get this finalized ASAP