### PR TITLE
remove stream param from request before sending

### DIFF
--- a/cohere_aws/client.py
+++ b/cohere_aws/client.py
@@ -378,6 +378,12 @@ class Client:
     def _bedrock_chat(self, json_params: Dict[str, Any], model_id: str) :
         if not model_id:
             raise CohereError("must supply model_id arg when calling bedrock")
+        if json_params['stream']:
+            stream = json_params['stream']
+            del json_params['stream']
+        else:
+            stream = False
+
         json_body = json.dumps(json_params)
         params = {
             'body': json_body,
@@ -385,7 +391,7 @@ class Client:
         }
 
         try:
-            if json_params['stream']:
+            if stream:
                 result = self._client.invoke_model_with_response_stream(
                     **params)
                 return StreamingChat(result['body'], self.mode)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere-aws',
-                 version='0.8.14',
+                 version='0.8.15',
                  author='Cohere',
                  author_email='support@cohere.ai',
                  description='A Python library for the Cohere endpoints in AWS Sagemaker & Bedrock',


### PR DESCRIPTION
bedrock will reject requests that have the 'stream' parameter present