### PR TITLE
Update Deploy rerank multilingual v3.0 model.ipynb

### DIFF
--- a/notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank multilingual v3.0 model.ipynb
+++ b/notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank multilingual v3.0 model.ipynb
@@ -138,7 +138,7 @@
    "outputs": [],
    "source": [
     "co = Client(region_name=region)\n",
-    "co.create_endpoint(arn=model_package_arn, endpoint_name=\"cohere-rerank-multilingual-v3.0\", instance_type=\"ml.g4dn.xlarge\", n_instances=1)\n",
+    "co.create_endpoint(arn=model_package_arn, endpoint_name=\"cohere-rerank-multilingual-v3-0\", instance_type=\"ml.g5.2xlarge\", n_instances=1)\n",
     "\n",
     "# If the endpoint is already created, you just need to connect to it\n",
     "# co.connect_to_endpoint(endpoint_name=\"cohere-rerank-multilingual-v3.0\")"


### PR DESCRIPTION
1. Updated the endpoint name from 'cohere-rerank-multilingual-v3.0. to 'cohere-rerank-multilingual-v3-0
2. Updated code with supported instance type ml.g5.2xlarge