### PR TITLE
docs: add readme to sagemaker dir

### DIFF
--- a/notebooks/sagemaker/README.md
+++ b/notebooks/sagemaker/README.md
@@ -1,0 +1,18 @@
+# Welcome to the cohere-aws Repository
+
+Welcome to the cohere-aws repository! This repository provides a collection of ready-made notebooks that allow you to interact seamlessly with Cohere models on AWS SageMaker. Whether you are looking to perform text generation, classification, embeddings, or reranking, our notebooks are designed to get you started quickly and efficiently.
+
+## Getting Started
+
+**Explore the Notebooks**:
+Navigate through the current directory and open any of the provided Jupyter notebooks to start interacting with Cohere models via AWS SageMaker.
+
+## Important Notice
+
+Cohere [python](https://github.com/cohere-ai/cohere-python) and [typescript](https://github.com/cohere-ai/cohere-typescript) SDKs now also support Bedrock and SageMaker! This is part of an effort to make it as frictionless as possible to get started with and switch between Cohere providers.
+
+Please see the [platform support docs](https://docs.cohere.com/docs/cohere-works-everywhere) for code snippets and the status of this transition or go straight to the [python](https://github.com/cohere-ai/cohere-python) and [typescript](https://github.com/cohere-ai/cohere-typescript) repos to start using Bedrock/SageMaker straight away.
+
+## AWS Security Best Practices
+
+When using these notebooks, please ensure you follow the [AWS Security Best Practices](https://docs.aws.amazon.com/general/latest/gr/aws-security-best-practices.html) to secure your AWS environment and resources.


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces a new README.md file for the `notebooks/sagemaker` directory. The file provides an overview of the `cohere-aws` repository, which offers a collection of notebooks for interacting with Cohere models on AWS SageMaker.

## New File Content:
- **Welcome and Introduction**: A brief welcome message and an overview of the repository's purpose, highlighting the ready-made notebooks for seamless interaction with Cohere models on AWS SageMaker.
- **Getting Started**: Instructions for users to explore the notebooks by navigating the current directory and opening the provided Jupyter notebooks to interact with Cohere models.
- **Important Notice**: Information about the Cohere Python and TypeScript SDKs now supporting Bedrock and SageMaker. Links to the relevant repositories and documentation are provided.
- **AWS Security Best Practices**: A reminder for users to follow the AWS Security Best Practices when using the notebooks to secure their AWS environment and resources, with a link to the relevant documentation.

<!-- end-generated-description -->