### PR TITLE
Support SageMaker BYO finetuning

### DIFF
--- a/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
+++ b/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
@@ -139,10 +139,10 @@
     "merged_weights_dir = \"<merged_weights_dir>\"\n",
     "\n",
     "# The S3 directory you want to save the merged weights\n",
-    "s3_merged_weights_dir = \"<s3_merged_weights_dir>\"\n",
+    "s3_checkpoint_dir = \"<s3_checkpoint_dir>\"\n",
     "\n",
     "# The S3 directory you want to save the exported TensorRT-LLM engine. Make sure you do not reuse the same S3 directory across multiple runs\n",
-    "s3_tensorrtllm_engine_dir = \"<s3_tensorrtllm_engine_dir>\"\n",
+    "s3_output_dir = \"<s3_output_dir>\"\n",
     "\n",
     "# The name of the export\n",
     "export_name = \"<export_name>\"\n",
@@ -227,7 +227,7 @@
    "source": [
     "%%time\n",
     "sess = sage.Session()\n",
-    "merged_weights = S3Uploader.upload(merged_weights_dir, s3_merged_weights_dir, sagemaker_session=sess)\n",
+    "merged_weights = S3Uploader.upload(merged_weights_dir, s3_checkpoint_dir, sagemaker_session=sess)\n",
     "print(\"merged_weights\", merged_weights)"
    ]
   },
@@ -242,7 +242,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create Cohere client and use it to export the merged weights to the TensorRT-LLM inference engine. The exported TensorRT-LLM engine will be stored in a tar file `{s3_tensorrtllm_engine_dir}/{export_name}.tar.gz` in S3, where the file name is the same as the `export_name`."
+    "Create Cohere client and use it to export the merged weights to the TensorRT-LLM inference engine. The exported TensorRT-LLM engine will be stored in a tar file `{s3_output_dir}/{export_name}.tar.gz` in S3, where the file name is the same as the `export_name`."
    ]
   },
   {
@@ -258,8 +258,8 @@
     "co.export_finetune(\n",
     "    arn=arn,\n",
     "    name=export_name,\n",
-    "    s3_merged_weights_dir=s3_merged_weights_dir,\n",
-    "    s3_tensorrtllm_engine_dir=s3_tensorrtllm_engine_dir,\n",
+    "    s3_checkpoint_dir=s3_checkpoint_dir,\n",
+    "    s3_output_dir=s3_output_dir,\n",
     "    instance_type=\"ml.p4de.24xlarge\",\n",
     "    role=\"ServiceRoleSagemaker\",\n",
     ")"
@@ -289,7 +289,7 @@
     "co.create_endpoint(\n",
     "    arn=arn,\n",
     "    endpoint_name=endpoint_name,\n",
-    "    s3_models_dir=s3_tensorrtllm_engine_dir,\n",
+    "    s3_models_dir=s3_output_dir,\n",
     "    recreate=True,\n",
     "    instance_type=\"ml.p4de.24xlarge\",\n",
     "    role=\"ServiceRoleSagemaker\",\n",
@@ -410,7 +410,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.14"
   },
   "vscode": {
    "interpreter": {

--- a/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
+++ b/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
@@ -1,0 +1,423 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deploy Your Own Finetuned Command-R-0824 Model from AWS Marketplace \n",
+    "\n",
+    "This sample notebook shows you how to deploy your own finetuned HuggingFace Command-R model [CohereForAI/c4ai-command-r-08-2024](https://huggingface.co/CohereForAI/c4ai-command-r-08-2024) using Amazon SageMaker. More specifically, assuming you already have the adapter weights or merged weights from your own finetuning of [CohereForAI/c4ai-command-r-08-2024](https://huggingface.co/CohereForAI/c4ai-command-r-08-2024), we will show you how to \n",
+    "1. Merge the adapter weights to the weights of the base model, if you bring only the adapter weights\n",
+    "2. Export the merged weights to the TensorRT-LLM inference engine using Amazon SageMaker\n",
+    "3. Deploy the engine as a SageMaker endpoint to serve your business use cases\n",
+    "\n",
+    "> **Note**: This is a reference notebook and it cannot run unless you make changes suggested in the notebook.\n",
+    "\n",
+    "## Pre-requisites:\n",
+    "\n",
+    "1. **Note: This notebook contains elements which render correctly in Jupyter interface. Open this notebook from an Amazon SageMaker Notebook Instance or Amazon SageMaker Studio.**\n",
+    "1. Ensure that IAM role used has **AmazonSageMakerFullAccess**\n",
+    "1. To deploy this ML model successfully, ensure that:\n",
+    "    1. Either your IAM role has these three permissions and you have authority to make AWS Marketplace subscriptions in the AWS account used: \n",
+    "        1. **aws-marketplace:ViewSubscriptions**\n",
+    "        1. **aws-marketplace:Unsubscribe**\n",
+    "        1. **aws-marketplace:Subscribe**  \n",
+    "    2. or your AWS account has a subscription to the packages for <span style=\"background-color: yellow\">Cohere Command R Bring Your Own Finetuning</span>. If so, skip step: [Subscribe to the bring your own finetuning algorithm](#1.-Subscribe-to-the-bring-your-own-finetuning-algorithm)\n",
+    "\n",
+    "## Contents:\n",
+    "\n",
+    "1. [Subscribe to the bring your own finetuning algorithm](#1.-Subscribe-to-the-bring-your-own-finetuning-algorithm)\n",
+    "2. [Preliminary setup](#2.-Preliminary-setup)\n",
+    "3. [Get the merged weights](#3.-Get-the-merged-weights)\n",
+    "4. [Upload the merged weights to S3](#4.-Upload-the-merged-weights-to-S3)\n",
+    "5. [Export the merged weights to the TensorRT-LLM inference engine](#5.-Export-the-merged-weights-to-the-TensorRT-LLM-inference-engine)\n",
+    "6. [Create an endpoint for inference from the exported engine](#6.-Create-an-endpoint-for-inference-from-the-exported-engine)\n",
+    "7. [Perform real-time inference by calling the endpoint](#7.-Perform-real-time-inference-by-calling-the-endpoint)\n",
+    "8. [Delete the endpoint (optional)](#8.-Delete-the-endpoint-(optional))\n",
+    "9. [Unsubscribe to the listing (optional)](#9.-Unsubscribe-to-the-listing-(optional))\n",
+    "\n",
+    "## Usage instructions:\n",
+    "\n",
+    "You can run this notebook one cell at a time (By using Shift+Enter for running a cell)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Subscribe to the bring your own finetuning algorithm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To subscribe to the algorithm:\n",
+    "1. Open the algorithm listing page <span style=\"background-color: yellow\">Cohere Command R Bring Your Own Finetuning</span>.\n",
+    "2. On the AWS Marketplace listing, click on the **Continue to Subscribe** button.\n",
+    "3. On the **Subscribe to this software** page, review and click on **\"Accept Offer\"** if you and your organization agrees with EULA, pricing, and support terms. On the \"Configure and launch\" page, make sure the ARN displayed in your region match with the ARN you will use below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Preliminary setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Install the Python packages you will use below and import them. For example, you can run the command below to install `cohere-aws` if you haven't done so."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade cohere-aws"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sagemaker as sage\n",
+    "\n",
+    "from cohere_aws import Client\n",
+    "from sagemaker.s3 import S3Uploader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make sure you have access to the resources in your AWS account. For example, you can configure an AWS profile by the command `aws configure sso` (see [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html#cli-configure-sso-configure)) and run the command below to set the environment variable `AWS_PROFILE` as your profile name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change \"<aws_profile>\" to your own AWS profile name\n",
+    "os.environ[\"AWS_PROFILE\"] = \"<aws_profile>\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, you need to set all the following variables using your own information. In general, do not add a trailing slash to these paths (otherwise some parts won't work)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The AWS region\n",
+    "region = \"<region>\"\n",
+    "\n",
+    "# The arn of the bring your own finetuning algorithm\n",
+    "arn = \"<arn>\"\n",
+    "\n",
+    "# The local directory of your adapter weights. No need to specify this, if you bring your own merged weights\n",
+    "adapter_weights_dir = \"<adapter_weights_dir>\"\n",
+    "\n",
+    "# The local directory you want to save the merged weights. Or the local directory of your own merged weights, if you bring your own merged weights\n",
+    "merged_weights_dir = \"<merged_weights_dir>\"\n",
+    "\n",
+    "# The S3 directory you want to save the merged weights\n",
+    "s3_merged_weights_dir = \"<s3_merged_weights_dir>\"\n",
+    "\n",
+    "# The S3 directory you want to save the exported TensorRT-LLM engine. Make sure you do not reuse the same S3 directory across multiple runs\n",
+    "s3_tensorrtllm_engine_dir = \"<s3_tensorrtllm_engine_dir>\"\n",
+    "\n",
+    "# The name of the export\n",
+    "export_name = \"<export_name>\"\n",
+    "\n",
+    "# The name of the SageMaker endpoint\n",
+    "endpoint_name = \"<endpoint_name>\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Get the merged weights"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Assuming you use HuggingFace's [PEFT](https://github.com/huggingface/peft) to finetune [CohereForAI/c4ai-command-r-08-2024](https://huggingface.co/CohereForAI/c4ai-command-r-08-2024) and get the adapter weights, you can then merge your adapter weights to the base model weights to get the merged weights as shown below. Skip this step if you have already got the merged weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "from peft import PeftModel\n",
+    "from transformers import CohereForCausalLM\n",
+    "\n",
+    "\n",
+    "def load_and_merge_model(base_model_name_or_path: str, adapter_weights_dir: str):\n",
+    "    \"\"\"\n",
+    "    Load the base model and the model finetuned by PEFT, and merge the adapter weights to the base weights to get a model with merged weights\n",
+    "    \"\"\"\n",
+    "    base_model = CohereForCausalLM.from_pretrained(base_model_name_or_path)\n",
+    "    peft_model = PeftModel.from_pretrained(base_model, adapter_weights_dir)\n",
+    "    merged_model = peft_model.merge_and_unload()\n",
+    "    return merged_model\n",
+    "\n",
+    "\n",
+    "def save_hf_model(output_dir: str, model, tokenizer=None, args=None):\n",
+    "    \"\"\"\n",
+    "    Save a HuggingFace model (and optionally tokenizer as well as additional args) to a local directory\n",
+    "    \"\"\"\n",
+    "    os.makedirs(output_dir, exist_ok=True)\n",
+    "    model.save_pretrained(output_dir, state_dict=None, safe_serialization=True)\n",
+    "    if tokenizer is not None:\n",
+    "        tokenizer.save_pretrained(output_dir)\n",
+    "    if args is not None:\n",
+    "        torch.save(args, os.path.join(output_dir, \"training_args.bin\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the merged model from adapter weights\n",
+    "merged_model = load_and_merge_model(\"CohereForAI/c4ai-command-r-08-2024\", adapter_weights_dir)\n",
+    "\n",
+    "# Save the merged weights to your local directory\n",
+    "save_hf_model(merged_weights_dir, merged_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Upload the merged weights to S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "sess = sage.Session()\n",
+    "merged_weights = S3Uploader.upload(merged_weights_dir, s3_merged_weights_dir, sagemaker_session=sess)\n",
+    "print(\"merged_weights\", merged_weights)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Export the merged weights to the TensorRT-LLM inference engine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create Cohere client and use it to export the merged weights to the TensorRT-LLM inference engine. The exported TensorRT-LLM engine will be stored in a tar file `{s3_tensorrtllm_engine_dir}/{export_name}.tar.gz` in S3, where the file name is the same as the `export_name`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "co = Client(region_name=region)\n",
+    "co.export_finetune(\n",
+    "    arn=arn,\n",
+    "    name=export_name,\n",
+    "    s3_merged_weights_dir=s3_merged_weights_dir,\n",
+    "    s3_tensorrtllm_engine_dir=s3_tensorrtllm_engine_dir,\n",
+    "    instance_type=\"ml.p4de.24xlarge\",\n",
+    "    role=\"ServiceRoleSagemaker\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Create an endpoint for inference from the exported engine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Cohere client provides a built-in method to create an endpoint for inference, which will automatically deploy the model from the TensorRT-LLM engine you just exported."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "co.create_endpoint(\n",
+    "    arn=arn,\n",
+    "    endpoint_name=endpoint_name,\n",
+    "    s3_models_dir=s3_tensorrtllm_engine_dir,\n",
+    "    recreate=True,\n",
+    "    instance_type=\"ml.p4de.24xlarge\",\n",
+    "    role=\"ServiceRoleSagemaker\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Perform real-time inference by calling the endpoint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, you can perform real-time inference by calling the endpoint you just deployed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If the endpoint is already deployed, you can directly connect to it\n",
+    "co.connect_to_endpoint(endpoint_name=endpoint_name)\n",
+    "\n",
+    "message = \"Classify the following text as either very negative, negative, neutral, positive or very positive: mr. deeds is , as comedy goes , very silly -- and in the best way.\"\n",
+    "result = co.chat(message=message)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also evaluate your finetuned model using a evaluation dataset. The following is an example with the [ScienceQA](https://scienceqa.github.io/) dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "eval_data_path = \"<path_to_scienceQA_eval.jsonl>\"\n",
+    "\n",
+    "total = 0\n",
+    "correct = 0\n",
+    "for line in tqdm(open(eval_data_path).readlines()):\n",
+    "    total += 1\n",
+    "    question_answer_json = json.loads(line)\n",
+    "    question = question_answer_json[\"messages\"][0][\"content\"]\n",
+    "    answer = question_answer_json[\"messages\"][1][\"content\"]\n",
+    "    model_ans = co.chat(message=question, temperature=0).text\n",
+    "    if model_ans == answer:\n",
+    "        correct += 1\n",
+    "\n",
+    "print(f\"Accuracy of finetuned model is %.3f\" % (correct / total))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Delete the endpoint (optional)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After you successfully performed the inference, you can delete the deployed endpoint to avoid being charged continuously."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "co.delete_endpoint()\n",
+    "co.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Unsubscribe to the listing (optional)\n",
+    "\n",
+    "If you would like to unsubscribe to the model package, follow these steps. Before you cancel the subscription, ensure that you do not have any [deployable models](https://console.aws.amazon.com/sagemaker/home#/models) created from the model package or using the algorithm. Note - You can find this information by looking at the container name associated with the model. \n",
+    "\n",
+    "**Steps to unsubscribe to product from AWS Marketplace**:\n",
+    "1. Navigate to __Machine Learning__ tab on [__Your Software subscriptions page__](https://aws.amazon.com/marketplace/ai/library?productType=ml&ref_=mlmp_gitdemo_indust)\n",
+    "2. Locate the listing that you want to cancel the subscription for, and then choose __Cancel Subscription__  to cancel the subscription.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "3b57b3736fb00bc0deb03789040183ddbda4c9eb8e8f6bef7ea4333bc64826af"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR adds a new method called `export_finetune` to `Client` to support the SageMaker BYO finetuning.

This PR also adds a Jupyter Notebook to show how to export the customer's own finetuned merged weights to TensorRT-LLM engine, and deploy the endpoint from the exported TensorRT-LLM engine.

This PR has been tested from end to end: every cell in the Jupyter Notebook has been run and tested, all of which work well.