### PR TITLE
Modify BYO Notebook

### DIFF
--- a/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
+++ b/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
@@ -387,13 +387,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 9. Unsubscribe to the listing (optional)\n",
-    "\n",
+    "## 9. Unsubscribe to the listing (optional)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "If you would like to unsubscribe to the model package, follow these steps. Before you cancel the subscription, ensure that you do not have any [deployable models](https://console.aws.amazon.com/sagemaker/home#/models) created from the model package or using the algorithm. Note - You can find this information by looking at the container name associated with the model. \n",
     "\n",
     "**Steps to unsubscribe to product from AWS Marketplace**:\n",
     "1. Navigate to __Machine Learning__ tab on [__Your Software subscriptions page__](https://aws.amazon.com/marketplace/ai/library?productType=ml&ref_=mlmp_gitdemo_indust)\n",
-    "2. Locate the listing that you want to cancel the subscription for, and then choose __Cancel Subscription__  to cancel the subscription.\n"
+    "2. Locate the listing that you want to cancel the subscription for, and then choose __Cancel Subscription__  to cancel the subscription."
    ]
   }
  ],

--- a/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
+++ b/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
@@ -22,7 +22,7 @@
     "        1. **aws-marketplace:ViewSubscriptions**\n",
     "        1. **aws-marketplace:Unsubscribe**\n",
     "        1. **aws-marketplace:Subscribe**  \n",
-    "    2. or your AWS account has a subscription to the packages for <span style=\"background-color: yellow\">Cohere Command R Bring Your Own Finetuning</span>. If so, skip step: [Subscribe to the bring your own finetuning algorithm](#1.-Subscribe-to-the-bring-your-own-finetuning-algorithm)\n",
+    "    2. or your AWS account has a subscription to the packages for **cohere-command-R-v2-byoft**. If so, skip step: [Subscribe to the bring your own finetuning algorithm](#1.-Subscribe-to-the-bring-your-own-finetuning-algorithm)\n",
     "\n",
     "## Contents:\n",
     "\n",
@@ -53,7 +53,7 @@
    "metadata": {},
    "source": [
     "To subscribe to the algorithm:\n",
-    "1. Open the algorithm listing page <span style=\"background-color: yellow\">Cohere Command R Bring Your Own Finetuning</span>.\n",
+    "1. Open the algorithm listing page **cohere-command-R-v2-byoft**.\n",
     "2. On the AWS Marketplace listing, click on the **Continue to Subscribe** button.\n",
     "3. On the **Subscribe to this software** page, review and click on **\"Accept Offer\"** if you and your organization agrees with EULA, pricing, and support terms. On the \"Configure and launch\" page, make sure the ARN displayed in your region match with the ARN you will use below."
    ]
@@ -148,7 +148,10 @@
     "export_name = \"<export_name>\"\n",
     "\n",
     "# The name of the SageMaker endpoint\n",
-    "endpoint_name = \"<endpoint_name>\""
+    "endpoint_name = \"<endpoint_name>\"\n",
+    "\n",
+    "# The instance type for export and inference. Now \"ml.p4de.24xlarge\" and \"ml.p5.48xlarge\" are supported\n",
+    "instance_type = \"<instance_type>\""
    ]
   },
   {
@@ -260,7 +263,7 @@
     "    name=export_name,\n",
     "    s3_checkpoint_dir=s3_checkpoint_dir,\n",
     "    s3_output_dir=s3_output_dir,\n",
-    "    instance_type=\"ml.p4de.24xlarge\",\n",
+    "    instance_type=instance_type,\n",
     "    role=\"ServiceRoleSagemaker\",\n",
     ")"
    ]
@@ -287,11 +290,11 @@
    "source": [
     "%%time\n",
     "co.create_endpoint(\n",
-    "    arn=arn,\n",
+    "    arn=arn[(arn.rfind(\"/\") + 1):],\n",
     "    endpoint_name=endpoint_name,\n",
     "    s3_models_dir=s3_output_dir,\n",
     "    recreate=True,\n",
-    "    instance_type=\"ml.p4de.24xlarge\",\n",
+    "    instance_type=instance_type,\n",
     "    role=\"ServiceRoleSagemaker\",\n",
     ")"
    ]


### PR DESCRIPTION
This PR modifies the BYO notebook:

- Remove the words highlighted in yellow and use **cohere-command-R-v2-byoft** instead
- Force the customer to set a variable `instance_type` at the very beginning to make sure they won't use different instance types for export and inference
- Remove the prefix in the algorithm ARN used for creating the endpoint by `arn[(arn.rfind("/") + 1):]`. If there is no `"/"` in `arn`, `arn.rfind("/")` returns `-1` and the `arn` remains the same