### PR TITLE
Change cohere-aws to cohere in the BYO notebook

### DIFF
--- a/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
+++ b/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
@@ -80,7 +80,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install cohere>=5.11.0"
+    "!pip install \"cohere>=5.11.0\""
    ]
   },
   {

--- a/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
+++ b/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
@@ -22,7 +22,7 @@
     "        1. **aws-marketplace:ViewSubscriptions**\n",
     "        1. **aws-marketplace:Unsubscribe**\n",
     "        1. **aws-marketplace:Subscribe**  \n",
-    "    2. or your AWS account has a subscription to the packages for **cohere-command-R-v2-byoft**. If so, skip step: [Subscribe to the bring your own finetuning algorithm](#subscribe)\n",
+    "    2. or your AWS account has a subscription to the packages for [Cohere Bring Your Own Fine-tuning](https://aws.amazon.com/marketplace/pp/prodview-5wt5pdnw3bbq6). If so, skip step: [Subscribe to the bring your own finetuning algorithm](#subscribe)\n",
     "\n",
     "### Contents:\n",
     "\n",
@@ -54,7 +54,7 @@
    "metadata": {},
    "source": [
     "To subscribe to the algorithm:\n",
-    "1. Open the algorithm listing page **cohere-command-R-v2-byoft**.\n",
+    "1. Open the algorithm listing page [Cohere Bring Your Own Fine-tuning](https://aws.amazon.com/marketplace/pp/prodview-5wt5pdnw3bbq6).\n",
     "2. On the AWS Marketplace listing, click on the **Continue to Subscribe** button.\n",
     "3. On the **Subscribe to this software** page, review and click on **\"Accept Offer\"** if you and your organization agrees with EULA, pricing, and support terms. On the \"Configure and launch\" page, make sure the ARN displayed in your region match with the ARN you will use below."
    ]
@@ -119,7 +119,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, you need to set all the following variables using your own information. In general, do not add a trailing slash to these paths (otherwise some parts won't work)."
+    "Finally, you need to set all the following variables using your own information. In general, do not add a trailing slash to these paths (otherwise some parts won't work). You can use either `ml.p4de.24xlarge` or `ml.p5.48xlarge` as the `instance_type` for Cohere Bring Your Own Fine-tuning, but the `instance_type` used for export and inference (endpoint creation) must be identical."
    ]
   },
   {
@@ -131,8 +131,21 @@
     "# The AWS region\n",
     "region = \"<region>\"\n",
     "\n",
-    "# The arn of the bring your own finetuning algorithm\n",
-    "arn = \"<arn>\"\n",
+    "# Get the arn of the bring your own finetuning algorithm by region\n",
+    "cohere_package = \"cohere-command-r-v2-byoft-8370167e649c32a1a5f00267cd334c2c\"\n",
+    "algorithm_map = {\n",
+    "    \"us-east-1\": f\"arn:aws:sagemaker:us-east-1:865070037744:algorithm/{cohere_package}\",\n",
+    "    \"us-east-2\": f\"arn:aws:sagemaker:us-east-2:057799348421:algorithm/{cohere_package}\",\n",
+    "    \"us-west-2\": f\"arn:aws:sagemaker:us-west-2:594846645681:algorithm/{cohere_package}\",\n",
+    "    \"eu-central-1\": f\"arn:aws:sagemaker:eu-central-1:446921602837:algorithm/{cohere_package}\",\n",
+    "    \"ap-southeast-1\": f\"arn:aws:sagemaker:ap-southeast-1:192199979996:algorithm/{cohere_package}\",\n",
+    "    \"ap-southeast-2\": f\"arn:aws:sagemaker:ap-southeast-2:666831318237:algorithm/{cohere_package}\",\n",
+    "    \"ap-northeast-1\": f\"arn:aws:sagemaker:ap-northeast-1:977537786026:algorithm/{cohere_package}\",\n",
+    "    \"ap-south-1\": f\"arn:aws:sagemaker:ap-south-1:077584701553:algorithm/{cohere_package}\",\n",
+    "}\n",
+    "if region not in algorithm_map:\n",
+    "    raise Exception(f\"Current region {region} is not supported.\")\n",
+    "arn = algorithm_map[region]\n",
     "\n",
     "# The local directory of your adapter weights. No need to specify this, if you bring your own merged weights\n",
     "adapter_weights_dir = \"<adapter_weights_dir>\"\n",
@@ -296,7 +309,7 @@
    "source": [
     "%%time\n",
     "co.sagemaker_finetuning.create_endpoint(\n",
-    "    arn=arn[(arn.rfind(\"/\") + 1):],\n",
+    "    arn=arn,\n",
     "    endpoint_name=endpoint_name,\n",
     "    s3_models_dir=s3_output_dir,\n",
     "    recreate=True,\n",
@@ -338,7 +351,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also evaluate your finetuned model using a evaluation dataset. The following is an example with the [ScienceQA](https://scienceqa.github.io/) dataset:"
+    "You can also evaluate your finetuned model using a evaluation dataset. The following is an example with the [ScienceQA](https://scienceqa.github.io/) evaluation data at [here](https://github.com/cohere-ai/notebooks/blob/main/notebooks/data/scienceQA_eval.jsonl)."
    ]
   },
   {

--- a/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
+++ b/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
@@ -22,19 +22,19 @@
     "        1. **aws-marketplace:ViewSubscriptions**\n",
     "        1. **aws-marketplace:Unsubscribe**\n",
     "        1. **aws-marketplace:Subscribe**  \n",
-    "    2. or your AWS account has a subscription to the packages for **cohere-command-R-v2-byoft**. If so, skip step: [Subscribe to the bring your own finetuning algorithm](#1.-Subscribe-to-the-bring-your-own-finetuning-algorithm)\n",
+    "    2. or your AWS account has a subscription to the packages for **cohere-command-R-v2-byoft**. If so, skip step: [Subscribe to the bring your own finetuning algorithm](#subscribe)\n",
     "\n",
     "### Contents:\n",
     "\n",
-    "1. [Subscribe to the bring your own finetuning algorithm](#1.-Subscribe-to-the-bring-your-own-finetuning-algorithm)\n",
-    "2. [Preliminary setup](#2.-Preliminary-setup)\n",
-    "3. [Get the merged weights](#3.-Get-the-merged-weights)\n",
-    "4. [Upload the merged weights to S3](#4.-Upload-the-merged-weights-to-S3)\n",
-    "5. [Export the merged weights to the TensorRT-LLM inference engine](#5.-Export-the-merged-weights-to-the-TensorRT-LLM-inference-engine)\n",
-    "6. [Create an endpoint for inference from the exported engine](#6.-Create-an-endpoint-for-inference-from-the-exported-engine)\n",
-    "7. [Perform real-time inference by calling the endpoint](#7.-Perform-real-time-inference-by-calling-the-endpoint)\n",
-    "8. [Delete the endpoint (optional)](#8.-Delete-the-endpoint-(optional))\n",
-    "9. [Unsubscribe to the listing (optional)](#9.-Unsubscribe-to-the-listing-(optional))\n",
+    "1. [Subscribe to the bring your own finetuning algorithm](#subscribe)\n",
+    "2. [Preliminary setup](#setup)\n",
+    "3. [Get the merged weights](#merge)\n",
+    "4. [Upload the merged weights to S3](#upload)\n",
+    "5. [Export the merged weights to the TensorRT-LLM inference engine](#export)\n",
+    "6. [Create an endpoint for inference from the exported engine](#endpoint)\n",
+    "7. [Perform real-time inference by calling the endpoint](#inference)\n",
+    "8. [Delete the endpoint (optional)](#delete)\n",
+    "9. [Unsubscribe to the listing (optional)](#unsubscribe)\n",
     "\n",
     "### Usage instructions:\n",
     "\n",
@@ -45,6 +45,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a name=\"subscribe\"></a>\n",
     "## 1. Subscribe to the bring your own finetuning algorithm"
    ]
   },
@@ -62,6 +63,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a name=\"setup\"></a>\n",
     "## 2. Preliminary setup"
    ]
   },
@@ -158,6 +160,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a name=\"merge\"></a>\n",
     "## 3. Get the merged weights"
    ]
   },
@@ -219,6 +222,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a name=\"upload\"></a>\n",
     "## 4. Upload the merged weights to S3"
    ]
   },
@@ -238,6 +242,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a name=\"export\"></a>\n",
     "## 5. Export the merged weights to the TensorRT-LLM inference engine"
    ]
   },
@@ -272,6 +277,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a name=\"endpoint\"></a>\n",
     "## 6. Create an endpoint for inference from the exported engine"
    ]
   },
@@ -303,6 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a name=\"inference\"></a>\n",
     "## 7. Perform real-time inference by calling the endpoint"
    ]
   },
@@ -363,6 +370,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a name=\"delete\"></a>\n",
     "## 8. Delete the endpoint (optional)"
    ]
   },
@@ -387,6 +395,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a name=\"unsubscribe\"></a>\n",
     "## 9. Unsubscribe to the listing (optional)"
    ]
   },

--- a/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
+++ b/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
@@ -2,9 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
    "source": [
-    "# Deploy Your Own Finetuned Command-R-0824 Model from AWS Marketplace \n",
+    "## Deploy Your Own Finetuned Command-R-0824 Model from AWS Marketplace \n",
     "\n",
     "This sample notebook shows you how to deploy your own finetuned HuggingFace Command-R model [CohereForAI/c4ai-command-r-08-2024](https://huggingface.co/CohereForAI/c4ai-command-r-08-2024) using Amazon SageMaker. More specifically, assuming you already have the adapter weights or merged weights from your own finetuning of [CohereForAI/c4ai-command-r-08-2024](https://huggingface.co/CohereForAI/c4ai-command-r-08-2024), we will show you how to \n",
     "1. Merge the adapter weights to the weights of the base model, if you bring only the adapter weights\n",
@@ -13,7 +15,7 @@
     "\n",
     "> **Note**: This is a reference notebook and it cannot run unless you make changes suggested in the notebook.\n",
     "\n",
-    "## Pre-requisites:\n",
+    "### Pre-requisites:\n",
     "\n",
     "1. **Note: This notebook contains elements which render correctly in Jupyter interface. Open this notebook from an Amazon SageMaker Notebook Instance or Amazon SageMaker Studio.**\n",
     "1. Ensure that IAM role used has **AmazonSageMakerFullAccess**\n",
@@ -24,7 +26,7 @@
     "        1. **aws-marketplace:Subscribe**  \n",
     "    2. or your AWS account has a subscription to the packages for **cohere-command-R-v2-byoft**. If so, skip step: [Subscribe to the bring your own finetuning algorithm](#1.-Subscribe-to-the-bring-your-own-finetuning-algorithm)\n",
     "\n",
-    "## Contents:\n",
+    "### Contents:\n",
     "\n",
     "1. [Subscribe to the bring your own finetuning algorithm](#1.-Subscribe-to-the-bring-your-own-finetuning-algorithm)\n",
     "2. [Preliminary setup](#2.-Preliminary-setup)\n",
@@ -36,7 +38,7 @@
     "8. [Delete the endpoint (optional)](#8.-Delete-the-endpoint-(optional))\n",
     "9. [Unsubscribe to the listing (optional)](#9.-Unsubscribe-to-the-listing-(optional))\n",
     "\n",
-    "## Usage instructions:\n",
+    "### Usage instructions:\n",
     "\n",
     "You can run this notebook one cell at a time (By using Shift+Enter for running a cell)."
    ]
@@ -69,7 +71,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Install the Python packages you will use below and import them. For example, you can run the command below to install `cohere-aws` if you haven't done so."
+    "Install the Python packages you will use below and import them. For example, you can run the command below to install `cohere` if you haven't done so."
    ]
   },
   {
@@ -80,7 +82,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws"
+    "!pip install cohere>=5.11.0"
    ]
   },
   {
@@ -89,10 +91,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import cohere\n",
     "import os\n",
     "import sagemaker as sage\n",
     "\n",
-    "from cohere_aws import Client\n",
     "from sagemaker.s3 import S3Uploader"
    ]
   },
@@ -257,8 +259,8 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "co = Client(region_name=region)\n",
-    "co.export_finetune(\n",
+    "co = cohere.SagemakerClient(aws_region=region)\n",
+    "co.sagemaker_finetuning.export_finetune(\n",
     "    arn=arn,\n",
     "    name=export_name,\n",
     "    s3_checkpoint_dir=s3_checkpoint_dir,\n",
@@ -289,7 +291,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "co.create_endpoint(\n",
+    "co.sagemaker_finetuning.create_endpoint(\n",
     "    arn=arn[(arn.rfind(\"/\") + 1):],\n",
     "    endpoint_name=endpoint_name,\n",
     "    s3_models_dir=s3_output_dir,\n",
@@ -320,10 +322,10 @@
    "outputs": [],
    "source": [
     "# If the endpoint is already deployed, you can directly connect to it\n",
-    "co.connect_to_endpoint(endpoint_name=endpoint_name)\n",
+    "co.sagemaker_finetuning.connect_to_endpoint(endpoint_name=endpoint_name)\n",
     "\n",
     "message = \"Classify the following text as either very negative, negative, neutral, positive or very positive: mr. deeds is , as comedy goes , very silly -- and in the best way.\"\n",
-    "result = co.chat(message=message)\n",
+    "result = co.sagemaker_finetuning.chat(message=message)\n",
     "print(result)"
    ]
   },
@@ -352,7 +354,7 @@
     "    question_answer_json = json.loads(line)\n",
     "    question = question_answer_json[\"messages\"][0][\"content\"]\n",
     "    answer = question_answer_json[\"messages\"][1][\"content\"]\n",
-    "    model_ans = co.chat(message=question, temperature=0).text\n",
+    "    model_ans = co.sagemaker_finetuning.chat(message=question, temperature=0).text\n",
     "    if model_ans == answer:\n",
     "        correct += 1\n",
     "\n",
@@ -379,8 +381,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "co.delete_endpoint()\n",
-    "co.close()"
+    "co.sagemaker_finetuning.delete_endpoint()\n",
+    "co.sagemaker_finetuning.close()"
    ]
   },
   {

--- a/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
+++ b/notebooks/sagemaker/Deploy your own finetuned command-r-0824.ipynb
@@ -2,9 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Deploy Your Own Finetuned Command-R-0824 Model from AWS Marketplace \n",
     "\n",

--- a/notebooks/sagemaker/Run command R finetuning.ipynb
+++ b/notebooks/sagemaker/Run command R finetuning.ipynb
@@ -349,7 +349,7 @@
     ")\n",
     "\n",
     "# If the endpoint is already created, you just need to connect to it\n",
-    "co.connect_to_endpoint(endpoint_name=endpoint_name)"
+    "co.sagemaker_finetuning.connect_to_endpoint(endpoint_name=endpoint_name)"
    ]
   },
   {

--- a/notebooks/sagemaker/Run command R finetuning.ipynb
+++ b/notebooks/sagemaker/Run command R finetuning.ipynb
@@ -173,11 +173,9 @@
    "source": [
     "sess = sage.Session()\n",
     "# TODO[Optional]: change it to your data\n",
-    "# You can download following example datasets from https://github.com/cohere-ai/cohere-aws/tree/main/notebooks/data and upload them\n",
-    "# to the root of this juyter notebook\n",
-    "train_dataset = S3Uploader.upload(\"./sample_finetune_scienceQA_train.jsonl\", s3_data_dir, sagemaker_session=sess)\n",
+    "train_dataset = S3Uploader.upload(\"../../examples/sample_finetune_scienceQA_train.jsonl\", s3_data_dir, sagemaker_session=sess)\n",
     "# optional eval dataset\n",
-    "eval_dataset = S3Uploader.upload(\"./sample_finetune_scienceQA_eval.jsonl\", s3_data_dir, sagemaker_session=sess)\n",
+    "eval_dataset = S3Uploader.upload(\"../../examples/sample_finetune_scienceQA_eval.jsonl\", s3_data_dir, sagemaker_session=sess)\n",
     "print(\"traint_dataset\", train_dataset)\n",
     "print(\"eval_dataset\", eval_dataset)"
    ]
@@ -224,7 +222,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "co = cohere.SagemakerClient(region_name=region)"
+    "co = cohere.SagemakerClient(aws_region=region)"
    ]
   },
   {
@@ -392,7 +390,7 @@
     "from tqdm import tqdm\n",
     "total = 0\n",
     "correct = 0\n",
-    "for line in tqdm(open('./sample_finetune_scienceQA_eval.jsonl').readlines()):\n",
+    "for line in tqdm(open('../../examples/sample_finetune_scienceQA_eval.jsonl').readlines()):\n",
     "    total += 1\n",
     "    question_answer_json = json.loads(line)\n",
     "    question = question_answer_json[\"messages\"][0][\"content\"]\n",


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces changes to the sample notebook, demonstrating the deployment of a fine-tuned HuggingFace Command-R model using Amazon SageMaker. The modifications primarily involve updating the notebook's code and structure to ensure compatibility with the latest Cohere library and Amazon SageMaker functionalities.

## Changes:
- The notebook's title is now formatted as a level 2 heading, ensuring consistency with Markdown standards.
- The `metadata` field in the notebook's cell structure is updated to include the `jp-MarkdownHeadingCollapsed` property, set to `true`.
- The installation command for the Python package has been modified from `cohere-aws` to `cohere`, reflecting the updated library name.
- The import statement now includes the `cohere` library, ensuring its availability for subsequent usage.
- The `Client` object instantiation has been replaced with `SagemakerClient`, a more specific class from the `cohere` library. This change enhances code clarity and leverages the specialized functionality of the `SagemakerClient` class.
- The `export_finetune`, `create_endpoint`, `connect_to_endpoint`, `chat`, `delete_endpoint`, and `close` methods are now accessed through the `sagemaker_finetuning` attribute of the `co` object. This modification aligns with the updated library structure and ensures that the code continues to function as expected.

<!-- end-generated-description -->