### PR TITLE
docs: update for arns and urls for r v2 finetuning + misc fixes

### DIFF
--- a/notebooks/sagemaker/Run command R finetuning.ipynb
+++ b/notebooks/sagemaker/Run command R finetuning.ipynb
@@ -18,7 +18,7 @@
     "        1. **aws-marketplace:ViewSubscriptions**\n",
     "        1. **aws-marketplace:Unsubscribe**\n",
     "        1. **aws-marketplace:Subscribe**  \n",
-    "    2. or your AWS account has a subscription to the packages for [Cohere Command R Finetuning](https://aws.amazon.com/marketplace/ai/configuration?productId=1762e582-e7df-47f0-a49f-98e22302a702). If so, skip step: [Subscribe to the finetune algorithm](#1.-Subscribe-to-the-finetune-algorithm)\n",
+    "    2. or your AWS account has a subscription to the packages for either [Cohere Command R 082024 Finetuning](https://aws.amazon.com/marketplace/pp/prodview-alpjcwhoq7pfk) or [Cohere Command R Finetuning](https://aws.amazon.com/marketplace/pp/prodview-2czs5tbao7b7c). If so, skip step: [Subscribe to the finetune algorithm](#1.-Subscribe-to-the-finetune-algorithm)\n",
     "\n",
     "## Contents:\n",
     "1. [Subscribe to the finetune algorithm](#1.-Subscribe-to-the-finetune-algorithm)\n",
@@ -47,7 +47,7 @@
    "metadata": {},
    "source": [
     "To subscribe to the model algorithm:\n",
-    "1. Open the algorithm listing page [Cohere Command R Finetuning](https://aws.amazon.com/marketplace/pp/prodview-2czs5tbao7b7c)\n",
+    "1. Open the algorithm listing page for either [Cohere Command R 082024 Finetuning](https://aws.amazon.com/marketplace/pp/prodview-alpjcwhoq7pfk) or [Cohere Command R Finetuning](https://aws.amazon.com/marketplace/pp/prodview-2czs5tbao7b7c)\n",
     "2. On the AWS Marketplace listing, click on the **Continue to Subscribe** button.\n",
     "3. On the **Subscribe to this software** page, review and click on **\"Accept Offer\"** if you and your organization agrees with EULA, pricing, and support terms. On the \"Configure and launch\" page, make sure ARN displayed in your region match with the ARN in the following cell."
    ]
@@ -83,8 +83,9 @@
    "source": [
     "region = boto3.Session().region_name\n",
     "\n",
-    "cohere_package = \"\"\n",
-    "# Legacy package\n",
+    "# Command R 082024 Finetuning\n",
+    "cohere_package = \"cohere-command-r-v2-ft-cf30836984573101bba9b820364893bc\"\n",
+    "# Legacy package for Command R Finetuning\n",
     "# cohere_package = \"cohere-command-r-ft-v-0-1-2-bae2282f0f4a30bca8bc6fea9efeb7ca\"\n",
     "\n",
     "# Mapping for algorithms\n",
@@ -137,23 +138,29 @@
     "\n",
     "JSONL:\n",
     "```\n",
-    "{'messages': \n",
-    " [{'role': 'System',\n",
-    "   'content': 'You are a chatbot trained to answer to my every question.'\n",
-    "  },\n",
-    "  {'role': 'User',\n",
-    "   'content': 'Hello'\n",
-    "  },\n",
-    "  {'role': 'Chatbot',\n",
-    "   'content': 'Greetings! How can I help you?'\n",
-    "  },\n",
-    "\t{'role': 'User',\n",
-    "   'content': 'What makes a good running route?'\n",
-    "  },\n",
-    "  {'role': 'Chatbot',\n",
-    "   'content': 'A sidewalk-lined road is ideal so that you’re up and off the road away from vehicular traffic.'\n",
-    "  }\n",
-    " ]\n",
+    "{\n",
+    "  \"messages\": [\n",
+    "    {\n",
+    "      \"role\": \"System\",\n",
+    "      \"content\": \"You are a chatbot trained to answer to my every question.\"\n",
+    "    },\n",
+    "    {\n",
+    "      \"role\": \"User\",\n",
+    "      \"content\": \"Hello\"\n",
+    "    },\n",
+    "    {\n",
+    "      \"role\": \"Chatbot\",\n",
+    "      \"content\": \"Greetings! How can I help you?\"\n",
+    "    },\n",
+    "    {\n",
+    "      \"role\": \"User\",\n",
+    "      \"content\": \"What makes a good running route?\"\n",
+    "    },\n",
+    "    {\n",
+    "      \"role\": \"Chatbot\",\n",
+    "      \"content\": \"A sidewalk-lined road is ideal so that you're up and off the road away from vehicular traffic.\"\n",
+    "    }\n",
+    "  ]\n",
     "}\n",
     "```\n"
    ]
@@ -166,7 +173,7 @@
    "source": [
     "sess = sage.Session()\n",
     "# TODO[Optional]: change it to your data\n",
-    "# You can download following datasets from https://github.com/cohere-ai/cohere-aws/tree/main/examples and upload them\n",
+    "# You can download following example datasets from https://github.com/cohere-ai/cohere-aws/tree/main/notebooks/data and upload them\n",
     "# to the root of this juyter notebook\n",
     "train_dataset = S3Uploader.upload(\"./sample_finetune_scienceQA_train.jsonl\", s3_data_dir, sagemaker_session=sess)\n",
     "# optional eval dataset\n",
@@ -226,7 +233,7 @@
    "source": [
     "#### Optional: Define hyperparameters\n",
     "\n",
-    "- `train_epochs`: Integer. This is the maximum number of training epochs to run for. Defaults to **1**.\n",
+    "- `train_epochs`: Integer. This is the maximum number of training epochs to run for. Defaults to **1**\n",
     "\n",
     "| Default | Min | Max |\n",
     "| --- | --- | --- |\n",
@@ -254,7 +261,7 @@
     "| --- | --- | --- |\n",
     "| 0.001 | 0.001 | 0.1 |\n",
     "\n",
-    "If the algorithm is **command-r-0824-ft**, you have the option to define:\n",
+    "If the algorithm is for **Command R 082024 Finetuning**, you have the option to define:\n",
     "- `lora_rank': Integer`. Lora adapter rank. Defaults to **32**\n",
     "\n",
     "| Default | Min | Max |\n",
@@ -282,7 +289,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create fine-tuning jobs for the uploaded datasets. Add a field for `eval_data` if you have pre-split your dataset and uploaded both training and evaluation datasets to S3. Remember to use p4de for Command-R Finetuning."
+    "Create fine-tuning jobs for the uploaded datasets. Add a field for `eval_data` if you have pre-split your dataset and uploaded both training and evaluation datasets to S3. You can use either `ml.p5d.48xlarge` or `ml.p4de.24xlarge` for Command R 082024 Finetuning and only `ml.p4de.24xlarge` for Command R Finetuning."
    ]
   },
   {
@@ -325,7 +332,7 @@
     "\n",
     "The Cohere AWS SDK provides a built-in method for creating an endpoint for inference. This will automatically deploy the model you finetuned earlier.\n",
     "\n",
-    "> **Note**: This is equivalent to creating and deploying a `ModelPackage` in SageMaker's SDK.\n"
+    "> **Note**: You can use either `ml.p5d.48xlarge` or `ml.p4de.24xlarge` for Command R 082024 Finetuning and only `ml.p4de.24xlarge` for Command R Finetuning. The instance type must be identical to the one used in the finetune creation step.\n"
    ]
   },
   {
@@ -439,9 +446,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the notebook for running Command R finetuning on SageMaker. It introduces a new version of the Command R finetuning package, **Cohere Command R 082024 Finetuning**, and provides instructions for using it alongside the existing **Cohere Command R Finetuning** package.

- The notebook now includes two package options for subscription: **Cohere Command R 082024 Finetuning** and **Cohere Command R Finetuning**.
- The algorithm listing page URLs have been updated to reflect the new package.
- The `cohere_package` variable has been updated to include the new package name and a comment indicating the legacy package.
- The JSONL example has been reformatted for better readability.
- The data download URL has been updated to point to the correct location.
- The description of the `train_epochs` hyperparameter has been updated to include the default value.
- The algorithm name has been updated in the description of the optional hyperparameters.
- The instance types for fine-tuning jobs have been updated to include options for both packages.
- The note about creating an endpoint for inference has been updated to include instance type options and a requirement for matching instance types between the finetune creation and inference steps.

<!-- end-generated-description -->