### PR TITLE
Update link to AWS Marketplace to point to Rerank V3

### DIFF
--- a/notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank multilingual v3.0 model.ipynb
+++ b/notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank multilingual v3.0 model.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "Cohere builds a collection of Large Language Models (LLMs) trained on a massive corpus of curated web data. Powering these models, our infrastructure enables our product to be deployed for a wide range of use cases. The use cases we power include generation (copy writing, etc), summarization, classification, content moderation, information extraction, semantic search, and contextual entity extraction\n",
     "\n",
-    "This sample notebook shows you how to deploy [cohere-rerank-multilingual](https://aws.amazon.com/marketplace/pp/prodview-pf7d2umihcseq) using Amazon SageMaker.\n",
+    "This sample notebook shows you how to deploy [cohere-rerank-multilingual](https://aws.amazon.com/marketplace/pp/prodview-ydysc72qticsw) using Amazon SageMaker.\n",
     "\n",
     "> **Note**: This is a reference notebook and it cannot run unless you make changes suggested in the notebook.\n",
     "\n",


### PR DESCRIPTION
Updated link to AWS Marketplace to point to Rerank V3 version (i.e. "Cohere Rerank 3 Model - Multilingual").  Previously, the link referenced V2.