### PR TITLE
fix: unreadable notebooks

### DIFF
--- a/notebooks/sagemaker/Deploy command-r-plus-0824.ipynb
+++ b/notebooks/sagemaker/Deploy command-r-plus-0824.ipynb
@@ -97,7 +97,7 @@
    "outputs": [],
    "source": [
     "cohere_packages = {\n",
-    "    'ml.p4de.24xlarge': \"cohere-command-r-plus-082024-a-1ab1cbe8895c337c9a7176ce34896a20",\n",
+    "    'ml.p4de.24xlarge': \"cohere-command-r-plus-082024-a-1ab1cbe8895c337c9a7176ce34896a20\",\n",
     "    'ml.p5.48xlarge': \"cohere-command-r-plus-082024-h-8a016dcc52513421b5612b2115898c11\",\n",
     "}\n",
     "\n",

--- a/notebooks/sagemaker/Deploy embed v3 model.ipynb
+++ b/notebooks/sagemaker/Deploy embed v3 model.ipynb
@@ -94,7 +94,7 @@
     "Multilingual Light: cohere-embed-multilingual-ligh-24df7ac178b138e9a2c9caa46b11cc7c\n",
     "\"\"\"\n",
     "# replace the arn below with the model package arn you want to deploy\n",
-    "cohere_package = \"cohere-embed-english-v3-8-1108-7e0739d809803e9380e75b954811a0cb"\n",
+    "cohere_package = \"cohere-embed-english-v3-8-1108-7e0739d809803e9380e75b954811a0cb\"\n",
     "\n",
     "# Mapping for Model Packages\n",
     "model_package_map = {\n",


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the `cohere_package` and `cohere_packages` variables in the `Deploy command-r-plus-0824.ipynb` and `Deploy embed v3 model.ipynb` notebooks respectively.

- In `Deploy command-r-plus-0824.ipynb`, the `cohere_packages` variable is updated to include the correct package name for the `'ml.p4de.24xlarge' instance.
- In `Deploy embed v3 model.ipynb`, the `cohere_package` variable is updated to include the correct package name for the `'cohere-embed-english-v3-8-1108' model.

<!-- end-generated-description -->