### PR TITLE
fix: use setuptools==69.5.1

### DIFF
--- a/notebooks/bedrock/Financial Multilingual Embeddings.ipynb
+++ b/notebooks/bedrock/Financial Multilingual Embeddings.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws hnswlib\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws hnswlib\n",
     "# If you upgrade the package, you need to restart the kernel"
    ]
   },

--- a/notebooks/bedrock/Finetune command light model.ipynb
+++ b/notebooks/bedrock/Finetune command light model.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "import cohere_aws\n",

--- a/notebooks/bedrock/Finetune command model.ipynb
+++ b/notebooks/bedrock/Finetune command model.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "import cohere_aws\n",

--- a/notebooks/bedrock/Query command XL.ipynb
+++ b/notebooks/bedrock/Query command XL.ipynb
@@ -79,7 +79,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "import cohere_aws\n",

--- a/notebooks/bedrock/Query command r plus.ipynb
+++ b/notebooks/bedrock/Query command r plus.ipynb
@@ -80,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "import cohere_aws\n",

--- a/notebooks/bedrock/Query command r.ipynb
+++ b/notebooks/bedrock/Query command r.ipynb
@@ -80,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "import cohere_aws\n",

--- a/notebooks/sagemaker/Deploy classification multilingual model.ipynb
+++ b/notebooks/sagemaker/Deploy classification multilingual model.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",

--- a/notebooks/sagemaker/Deploy command light.ipynb
+++ b/notebooks/sagemaker/Deploy command light.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",

--- a/notebooks/sagemaker/Deploy command-r-0824.ipynb
+++ b/notebooks/sagemaker/Deploy command-r-0824.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",

--- a/notebooks/sagemaker/Deploy command-r-plus-0824.ipynb
+++ b/notebooks/sagemaker/Deploy command-r-plus-0824.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",

--- a/notebooks/sagemaker/Deploy command-r-plus.ipynb
+++ b/notebooks/sagemaker/Deploy command-r-plus.ipynb
@@ -86,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",

--- a/notebooks/sagemaker/Deploy command-r.ipynb
+++ b/notebooks/sagemaker/Deploy command-r.ipynb
@@ -86,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",

--- a/notebooks/sagemaker/Deploy command.ipynb
+++ b/notebooks/sagemaker/Deploy command.ipynb
@@ -72,7 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",

--- a/notebooks/sagemaker/Deploy embed v3 model.ipynb
+++ b/notebooks/sagemaker/Deploy embed v3 model.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",

--- a/notebooks/sagemaker/Deploy multilingual model.ipynb
+++ b/notebooks/sagemaker/Deploy multilingual model.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",

--- a/notebooks/sagemaker/Deploy summarize.ipynb
+++ b/notebooks/sagemaker/Deploy summarize.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",

--- a/notebooks/sagemaker/rerank_v2_notebooks/Deploy rerank english v2.0 model.ipynb
+++ b/notebooks/sagemaker/rerank_v2_notebooks/Deploy rerank english v2.0 model.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",

--- a/notebooks/sagemaker/rerank_v2_notebooks/Deploy rerank multilingual v2.0 model.ipynb
+++ b/notebooks/sagemaker/rerank_v2_notebooks/Deploy rerank multilingual v2.0 model.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",

--- a/notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank english v3.0 model.ipynb
+++ b/notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank english v3.0 model.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",

--- a/notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank multilingual v3.0 model.ipynb
+++ b/notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank multilingual v3.0 model.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",

--- a/notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank nimble english v3.0 model.ipynb
+++ b/notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank nimble english v3.0 model.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",

--- a/notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank nimble multilingual v3.0 model.ipynb
+++ b/notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank nimble multilingual v3.0 model.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `!pip install` command in several notebooks to include the `setuptools==69.5.1` package. This change ensures that the required version of the `setuptools` package is installed alongside the `cohere-aws` package.

- `notebooks/bedrock/Financial Multilingual Embeddings.ipynb`
- `notebooks/bedrock/Finetune command light model.ipynb`
- `notebooks/bedrock/Finetune command model.ipynb`
- `notebooks/bedrock/Query command XL.ipynb`
- `notebooks/bedrock/Query command r plus.ipynb`
- `notebooks/bedrock/Query command r.ipynb`
- `notebooks/sagemaker/Deploy classification multilingual model.ipynb`
- `notebooks/sagemaker/Deploy command light.ipynb`
- `notebooks/sagemaker/Deploy command-r-0824.ipynb`
- `notebooks/sagemaker/Deploy command-r-plus-0824.ipynb`
- `notebooks/sagemaker/Deploy command-r-plus.ipynb`
- `notebooks/sagemaker/Deploy command-r.ipynb`
- `notebooks/sagemaker/Deploy command.ipynb`
- `notebooks/sagemaker/Deploy embed v3 model.ipynb`
- `notebooks/sagemaker/Deploy multilingual model.ipynb`
- `notebooks/sagemaker/Deploy summarize.ipynb`
- `notebooks/sagemaker/rerank_v2_notebooks/Deploy rerank english v2.0 model.ipynb`
- `notebooks/sagemaker/rerank_v2_notebooks/Deploy rerank multilingual v2.0 model.ipynb`
- `notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank english v3.0 model.ipynb`
- `notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank multilingual v3.0 model.ipynb`
- `notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank nimble english v3.0 model.ipynb`
- `notebooks/sagemaker/rerank_v3_notebooks/Deploy rerank nimble multilingual v3.0 model.ipynb`

<!-- end-generated-description -->