### PR TITLE
Use cohere-python sdk

### DIFF
--- a/notebooks/sagemaker/Deploy rerank-v3.5.ipynb
+++ b/notebooks/sagemaker/Deploy rerank-v3.5.ipynb
@@ -200,9 +200,9 @@
    "source": [
     "import cohere\n",
     "\n",
-    "co = cohere.SagemakerClientV2()\n",
+    "co_sdk = cohere.SagemakerClientV2()\n",
     "\n",
-    "response = co.rerank(model=endpoint_name, documents=documents, query='What emails have been about returning items?', top_n=5)"
+    "response = co_sdk.rerank(model=endpoint_name, documents=documents, query='What emails have been about returning items?', top_n=5)"
    ]
   },
   {

--- a/notebooks/sagemaker/Deploy rerank-v3.5.ipynb
+++ b/notebooks/sagemaker/Deploy rerank-v3.5.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws zipp cohere\n",
     "# if you upgrade the package, you need to restart the kernel\n",
     "\n",
     "from cohere_aws import Client\n",
@@ -139,10 +139,8 @@
    "outputs": [],
    "source": [
     "co = Client(region_name=region)\n",
-    "co.create_endpoint(arn=model_package_arn, endpoint_name=\"cohere-rerank-v3-5\", instance_type=\"ml.g5.xlarge\", n_instances=1)\n",
-    "\n",
-    "# If the endpoint is already created, you just need to connect to it\n",
-    "# co.connect_to_endpoint(endpoint_name=\"cohere-rerank-v3-5\")"
+    "endpoint_name=\"cohere-rerank-v3-5\"\n",
+    "co.create_endpoint(arn=model_package_arn, endpoint_name=endpoint_name, instance_type=\"ml.g5.xlarge\", n_instances=1)"
    ]
   },
   {
@@ -200,7 +198,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "response = co.rerank(documents=documents, query='What emails have been about returning items?', top_n=5)"
+    "import cohere\n",
+    "\n",
+    "co = cohere.SagemakerClientV2()\n",
+    "\n",
+    "response = co.rerank(model=\"cohere-rerank-v3-5\", documents=documents, query='What emails have been about returning items?', top_n=5)"
    ]
   },
   {

--- a/notebooks/sagemaker/Deploy rerank-v3.5.ipynb
+++ b/notebooks/sagemaker/Deploy rerank-v3.5.ipynb
@@ -202,7 +202,7 @@
     "\n",
     "co = cohere.SagemakerClientV2()\n",
     "\n",
-    "response = co.rerank(model=\"cohere-rerank-v3-5\", documents=documents, query='What emails have been about returning items?', top_n=5)"
+    "response = co.rerank(model=endpoint_name, documents=documents, query='What emails have been about returning items?', top_n=5)"
    ]
   },
   {


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `Deploy rerank-v3.5.ipynb` notebook to use the latest version of the Cohere AWS package and the Cohere SDK.

## Changes
- The `pip install` command has been updated to include the `zipp` and `cohere` packages.
- The `co.create_endpoint` function now takes an `endpoint_name` parameter, which is set to `"cohere-rerank-v3-5".
- The `co.rerank` function has been updated to use the `cohere.SagemakerClientV2()` class and the `model` parameter has been added to specify the model name.

<!-- end-generated-description -->