### PR TITLE
add embed-v4 notebook with placeholder links

### DIFF
--- a/notebooks/sagemaker/Deploy embed v4 model.ipynb
+++ b/notebooks/sagemaker/Deploy embed v4 model.ipynb
@@ -1,0 +1,334 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deploy cohere Embed V3 Model Package from AWS Marketplace \n",
+    "\n",
+    "\n",
+    "Cohere builds a collection of Large Language Models (LLMs) trained on a massive corpus of curated web data. Powering these models, our infrastructure enables our product to be deployed for a wide range of use cases. The use cases we power include generation (copy writing, etc), summarization, classification, content moderation, information extraction, semantic search, and contextual entity extraction\n",
+    "\n",
+    "This sample notebook shows you how to deploy the Cohere Embed v3 family of models using Amazon SageMaker:\n",
+    "1. [Cohere Embed Model v3 - English](https://aws.amazon.com/marketplace/pp/prodview-qd64mji3pbnvk)\n",
+    "2. [Cohere Embed Light Model v3 - English](https://aws.amazon.com/marketplace/pp/prodview-c4dwczm5vr6bs)\n",
+    "3. [Cohere Embed Model v3 - Multilingual](https://aws.amazon.com/marketplace/pp/prodview-b4mpgdxvpa3v6)\n",
+    "4. [Cohere Embed Light v3 - Multilingual](https://aws.amazon.com/marketplace/pp/prodview-7uw3bomgawhre)\n",
+    "\n",
+    "> **Note**: This is a reference notebook and it cannot run unless you make changes suggested in the notebook.\n",
+    "\n",
+    "## Pre-requisites:\n",
+    "1. **Note**: This notebook contains elements which render correctly in Jupyter interface. Open this notebook from an Amazon SageMaker Notebook Instance or Amazon SageMaker Studio.\n",
+    "1. Ensure that IAM role used has **AmazonSageMakerFullAccess**\n",
+    "1. To deploy this ML model successfully, ensure that:\n",
+    "    1. Either your IAM role has these three permissions and you have authority to make AWS Marketplace subscriptions in the AWS account used: \n",
+    "        1. **aws-marketplace:ViewSubscriptions**\n",
+    "        1. **aws-marketplace:Unsubscribe**\n",
+    "        1. **aws-marketplace:Subscribe**  \n",
+    "    2. or your AWS account has a subscription to one of the models listed above. If so, skip step: [Subscribe to the model package](#1.-Subscribe-to-the-model-package)\n",
+    "\n",
+    "## Contents:\n",
+    "1. [Subscribe to the model package](#1.-Subscribe-to-the-model-package)\n",
+    "2. [Create an endpoint and perform real-time inference](#2.-Create-an-endpoint-and-perform-real-time-inference)\n",
+    "   1. [Create an endpoint](#A.-Create-an-endpoint)\n",
+    "   2. [Create input payload](#B.-Create-input-payload)\n",
+    "   3. [Perform real-time inference](#C.-Perform-real-time-inference)\n",
+    "   4. [Visualize output](#D.-Visualize-output)\n",
+    "   5. [Writing a blobpost with co.generate](#E.-writing-a-blobpost-with-cogenerate)\n",
+    "   6. [Entity Extraction using co.generate](#F.-entity-extraction-using-cogenerate)\n",
+    "   7. [Article Summarization using co.generate](#G.-article-summarization-using-cogenerate)\n",
+    "   5. [Delete the endpoint](#H.-Delete-the-endpoint)\n",
+    "3. [Clean-up](#4.-Clean-up)\n",
+    "    1. [Delete the model](#A.-Delete-the-model)\n",
+    "    2. [Unsubscribe to the listing (optional)](#B.-Unsubscribe-to-the-listing-(optional))\n",
+    "    \n",
+    "\n",
+    "## Usage instructions\n",
+    "You can run this notebook one cell at a time (By using Shift+Enter for running a cell)."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Subscribe to the model package"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To subscribe to the model package:\n",
+    "1. Open the model package listing page, for example [Cohere Embed Model v3 - English](https://aws.amazon.com/marketplace/pp/prodview-qd64mji3pbnvk)\n",
+    "1. On the AWS Marketplace listing, click on the **Continue to subscribe** button.\n",
+    "1. On the **Subscribe to this software** page, review and click on **\"Accept Offer\"** if you and your organization agrees with EULA, pricing, and support terms. \n",
+    "1. Once you click on **Continue to configuration button** and then choose a **region**, you will see a **Product Arn** displayed. This is the model package ARN that you need to specify while creating a deployable model using Boto3. Copy the ARN corresponding to your region and specify the same in the following cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade setuptools==69.5.1 cohere-aws\n",
+    "# if you upgrade the package, you need to restart the kernel\n",
+    "\n",
+    "from cohere_aws import Client\n",
+    "import boto3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"\n",
+    "English: cohere-embed-english-v3-8-0117-6d3f676bd44232428f648851d90f9f9c\n",
+    "English Light: cohere-embed-english-light-v3--928cc4805d20361da2d0b55cd341bd35\n",
+    "Multilingual: cohere-embed-multilingual-v3-8-415f7fd7b84f35c8abf08b6788d34d62\n",
+    "Multilingual Light: cohere-embed-multilingual-ligh-6031229712423c6e8476aeeb96dba7b3\n",
+    "\"\"\"\n",
+    "# replace the arn below with the model package arn you want to deploy\n",
+    "cohere_package = \"cohere-embed-english-v3-8-0117-6d3f676bd44232428f648851d90f9f9c\"\n",
+    "\n",
+    "# Mapping for Model Packages\n",
+    "model_package_map = {\n",
+    "    \"us-east-1\": f\"arn:aws:sagemaker:us-east-1:865070037744:model-package/{cohere_package}\",\n",
+    "    \"us-east-2\": f\"arn:aws:sagemaker:us-east-2:057799348421:model-package/{cohere_package}\",\n",
+    "    \"us-west-1\": f\"arn:aws:sagemaker:us-west-1:382657785993:model-package/{cohere_package}\",\n",
+    "    \"us-west-2\": f\"arn:aws:sagemaker:us-west-2:594846645681:model-package/{cohere_package}\",\n",
+    "    \"ca-central-1\": f\"arn:aws:sagemaker:ca-central-1:470592106596:model-package/{cohere_package}\",\n",
+    "    \"eu-central-1\": f\"arn:aws:sagemaker:eu-central-1:446921602837:model-package/{cohere_package}\",\n",
+    "    \"eu-west-1\": f\"arn:aws:sagemaker:eu-west-1:985815980388:model-package/{cohere_package}\",\n",
+    "    \"eu-west-2\": f\"arn:aws:sagemaker:eu-west-2:856760150666:model-package/{cohere_package}\",\n",
+    "    \"eu-west-3\": f\"arn:aws:sagemaker:eu-west-3:843114510376:model-package/{cohere_package}\",\n",
+    "    \"eu-north-1\": f\"arn:aws:sagemaker:eu-north-1:136758871317:model-package/{cohere_package}\",\n",
+    "    \"ap-southeast-1\": f\"arn:aws:sagemaker:ap-southeast-1:192199979996:model-package/{cohere_package}\",\n",
+    "    \"ap-southeast-2\": f\"arn:aws:sagemaker:ap-southeast-2:666831318237:model-package/{cohere_package}\",\n",
+    "    \"ap-northeast-2\": f\"arn:aws:sagemaker:ap-northeast-2:745090734665:model-package/{cohere_package}\",\n",
+    "    \"ap-northeast-1\": f\"arn:aws:sagemaker:ap-northeast-1:977537786026:model-package/{cohere_package}\",\n",
+    "    \"ap-south-1\": f\"arn:aws:sagemaker:ap-south-1:077584701553:model-package/{cohere_package}\",\n",
+    "    \"sa-east-1\": f\"arn:aws:sagemaker:sa-east-1:270155090741:model-package/{cohere_package}\",\n",
+    "}\n",
+    "\n",
+    "region = boto3.Session().region_name\n",
+    "if region not in model_package_map.keys():\n",
+    "    raise Exception(f\"Current boto3 session region {region} is not supported.\")\n",
+    "\n",
+    "model_package_arn = model_package_map[region]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Create an endpoint and perform real-time inference"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to understand how real-time inference with Amazon SageMaker works, see [Documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-hosting.html)."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A. Create an endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "co = Client(region_name=region)\n",
+    "co.create_endpoint(arn=model_package_arn, endpoint_name=\"cohere-embed-english-v3\", instance_type=\"ml.g5.xlarge\", n_instances=1)\n",
+    "\n",
+    "# If the endpoint is already created, you just need to connect to it\n",
+    "# co.connect_to_endpoint(endpoint_name=\"cohere-embed-english-v3\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once endpoint has been created, you would be able to perform real-time inference."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### B. Create input payload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "texts = [\n",
+    "    \"When are you open?\", \n",
+    "    \"When do you close?\", \n",
+    "    \"What are the hours?\", \n",
+    "    \"Are you open on weekends?\", \n",
+    "    \"Are you available on holidays?\", \n",
+    "    \"How much is a burger?\", \n",
+    "    \"What\\'s the price of a meal?\", \n",
+    "    \"How much for a few burgers?\", \n",
+    "    \"Do you have a vegan option?\", \n",
+    "    \"Do you have vegetarian?\", \n",
+    "    \"Do you serve non-meat alternatives?\", \n",
+    "    \"Do you have milkshakes?\", \n",
+    "    \"Milkshake\", \n",
+    "    \"Do you have desert?\", \n",
+    "    \"Can I bring my child?\", \n",
+    "    \"Are you kid friendly?\", \n",
+    "    \"Do you have booster seats?\", \n",
+    "    \"Do you do delivery?\", \n",
+    "    \"Is there takeout?\", \n",
+    "    \"Do you deliver?\", \n",
+    "    \"Can I have it delivered?\", \n",
+    "    \"Can you bring it to me?\", \n",
+    "    \"Do you have space for a party?\", \n",
+    "    \"Can you accommodate large groups?\", \n",
+    "    \"Can I book a party here?\"\n",
+    "]\n",
+    "\n",
+    "# input_type is required for v3 models and must be one of `classification`, 'clustering', 'search_query', 'search_document'\n",
+    "input_type = 'search_query'"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### C. Perform real-time inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = co.embed(texts=texts, input_type=input_type, truncate='END')"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### D. Visualize output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'Embeddings: {response.embeddings}') "
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Clean-up"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A. Delete the model"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that you have successfully performed a real-time inference, you do not need the endpoint any more. You can terminate the endpoint to avoid being charged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "co.delete_endpoint()\n",
+    "co.close()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### B. Unsubscribe to the listing (optional)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you would like to unsubscribe to the model package, follow these steps. Before you cancel the subscription, ensure that you do not have any [deployable model](https://console.aws.amazon.com/sagemaker/home#/models) created from the model package or using the algorithm. Note - You can find this information by looking at the container name associated with the model. \n",
+    "\n",
+    "**Steps to unsubscribe to product from AWS Marketplace**:\n",
+    "1. Navigate to __Machine Learning__ tab on [__Your Software subscriptions page__](https://aws.amazon.com/marketplace/ai/library?productType=ml&ref_=mlmp_gitdemo_indust)\n",
+    "2. Locate the listing that you want to cancel the subscription for, and then choose __Cancel Subscription__  to cancel the subscription.\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "instance_type": "ml.t3.medium",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.16"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR adds a notebook that demonstrates how to deploy the Cohere Embed v3 family of models using Amazon SageMaker.

- Subscribe to the model package
- Create an endpoint and perform real-time inference
- Create input payload
- Perform real-time inference
- Visualize output
- Writing a blobpost with co.generate
- Entity Extraction using co.generate
- Article Summarization using co.generate
- Delete the endpoint
- Clean-up
- Delete the model
- Unsubscribe to the listing (optional)

<!-- end-generated-description -->