### PR TITLE
update embed v4 links

### DIFF
--- a/notebooks/sagemaker/Deploy embed v4 model.ipynb
+++ b/notebooks/sagemaker/Deploy embed v4 model.ipynb
@@ -5,16 +5,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Deploy cohere Embed V3 Model Package from AWS Marketplace \n",
+    "# Deploy cohere Embed V4 Model Package from AWS Marketplace \n",
     "\n",
     "\n",
     "Cohere builds a collection of Large Language Models (LLMs) trained on a massive corpus of curated web data. Powering these models, our infrastructure enables our product to be deployed for a wide range of use cases. The use cases we power include generation (copy writing, etc), summarization, classification, content moderation, information extraction, semantic search, and contextual entity extraction\n",
     "\n",
-    "This sample notebook shows you how to deploy the Cohere Embed v3 family of models using Amazon SageMaker:\n",
-    "1. [Cohere Embed Model v3 - English](https://aws.amazon.com/marketplace/pp/prodview-qd64mji3pbnvk)\n",
-    "2. [Cohere Embed Light Model v3 - English](https://aws.amazon.com/marketplace/pp/prodview-c4dwczm5vr6bs)\n",
-    "3. [Cohere Embed Model v3 - Multilingual](https://aws.amazon.com/marketplace/pp/prodview-b4mpgdxvpa3v6)\n",
-    "4. [Cohere Embed Light v3 - Multilingual](https://aws.amazon.com/marketplace/pp/prodview-7uw3bomgawhre)\n",
+    "This sample notebook shows you how to deploy [cohere-embed-v4](https://aws.amazon.com/marketplace/pp/prodview-g53hj27nurqc6) using Amazon SageMaker:\n",
     "\n",
     "> **Note**: This is a reference notebook and it cannot run unless you make changes suggested in the notebook.\n",
     "\n",
@@ -35,10 +31,6 @@
     "   2. [Create input payload](#B.-Create-input-payload)\n",
     "   3. [Perform real-time inference](#C.-Perform-real-time-inference)\n",
     "   4. [Visualize output](#D.-Visualize-output)\n",
-    "   5. [Writing a blobpost with co.generate](#E.-writing-a-blobpost-with-cogenerate)\n",
-    "   6. [Entity Extraction using co.generate](#F.-entity-extraction-using-cogenerate)\n",
-    "   7. [Article Summarization using co.generate](#G.-article-summarization-using-cogenerate)\n",
-    "   5. [Delete the endpoint](#H.-Delete-the-endpoint)\n",
     "3. [Clean-up](#4.-Clean-up)\n",
     "    1. [Delete the model](#A.-Delete-the-model)\n",
     "    2. [Unsubscribe to the listing (optional)](#B.-Unsubscribe-to-the-listing-(optional))\n",
@@ -62,7 +54,7 @@
    "metadata": {},
    "source": [
     "To subscribe to the model package:\n",
-    "1. Open the model package listing page, for example [Cohere Embed Model v3 - English](https://aws.amazon.com/marketplace/pp/prodview-qd64mji3pbnvk)\n",
+    "1. Open the model package listing page [cohere-embed-v4](https://aws.amazon.com/marketplace/pp/prodview-qd64mji3pbnvk)\n",
     "1. On the AWS Marketplace listing, click on the **Continue to subscribe** button.\n",
     "1. On the **Subscribe to this software** page, review and click on **\"Accept Offer\"** if you and your organization agrees with EULA, pricing, and support terms. \n",
     "1. Once you click on **Continue to configuration button** and then choose a **region**, you will see a **Product Arn** displayed. This is the model package ARN that you need to specify while creating a deployable model using Boto3. Copy the ARN corresponding to your region and specify the same in the following cell."
@@ -87,14 +79,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"\n",
-    "English: cohere-embed-english-v3-8-0117-6d3f676bd44232428f648851d90f9f9c\n",
-    "English Light: cohere-embed-english-light-v3--928cc4805d20361da2d0b55cd341bd35\n",
-    "Multilingual: cohere-embed-multilingual-v3-8-415f7fd7b84f35c8abf08b6788d34d62\n",
-    "Multilingual Light: cohere-embed-multilingual-ligh-6031229712423c6e8476aeeb96dba7b3\n",
-    "\"\"\"\n",
-    "# replace the arn below with the model package arn you want to deploy\n",
-    "cohere_package = \"cohere-embed-english-v3-8-0117-6d3f676bd44232428f648851d90f9f9c\"\n",
+    "cohere_package = \"cohere-embed-v4-1-04072025-17ec0571acd93686b6cfb44babe01d66\"\n",
     "\n",
     "# Mapping for Model Packages\n",
     "model_package_map = {\n",
@@ -154,10 +139,10 @@
    "outputs": [],
    "source": [
     "co = Client(region_name=region)\n",
-    "co.create_endpoint(arn=model_package_arn, endpoint_name=\"cohere-embed-english-v3\", instance_type=\"ml.g5.xlarge\", n_instances=1)\n",
+    "co.create_endpoint(arn=model_package_arn, endpoint_name=\"cohere-embed-v4\", instance_type=\"ml.g5.xlarge\", n_instances=1)\n",
     "\n",
     "# If the endpoint is already created, you just need to connect to it\n",
-    "# co.connect_to_endpoint(endpoint_name=\"cohere-embed-english-v3\")"
+    "# co.connect_to_endpoint(endpoint_name=\"cohere-embed-v4\")"
    ]
   },
   {
@@ -210,7 +195,7 @@
     "    \"Can I book a party here?\"\n",
     "]\n",
     "\n",
-    "# input_type is required for v3 models and must be one of `classification`, 'clustering', 'search_query', 'search_document'\n",
+    "# input_type is required for v4 models and must be one of `classification`, 'clustering', 'search_query', 'search_document'\n",
     "input_type = 'search_query'"
    ]
   },


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the notebook to deploy the Cohere Embed v4 model using Amazon SageMaker. It removes references to the v3 models and updates the code and documentation to reflect the changes.

**Changes:**
- Updated the title to reflect the new model version.
- Removed the list of v3 models and replaced it with a link to the cohere-embed-v4 model.
- Updated the table of contents by removing references to co.generate and reordering the sections.
- Updated the subscription instructions to reflect the new model version.
- Updated the model package ARN to use the v4 model.
- Updated the endpoint creation code to use the v4 model name.
- Updated the input type comment to reflect the new model version.

<!-- end-generated-description -->